### PR TITLE
Add logic to disable action buttons based on experiment state

### DIFF
--- a/web-app/src/components/ExperimentsTable.tsx
+++ b/web-app/src/components/ExperimentsTable.tsx
@@ -21,6 +21,7 @@ import {
   type ExternalToolId,
 } from "../config"
 import { ExternalLinkButton } from "./ExternalLinkButton"
+import { isActionDisabled } from "./experimentActions"
 
 /** Context key for experiments table sorting */
 const SORT_CONTEXT = "experiments"
@@ -102,6 +103,7 @@ function ActionIconButton({
   toolId,
   params,
   externalUrl,
+  disabled = false,
 }: {
   label: string
   icon: React.ReactNode
@@ -109,10 +111,14 @@ function ActionIconButton({
   toolId?: ExternalToolId
   params?: Record<string, string | number>
   externalUrl?: string
+  disabled?: boolean
 }) {
-  const className = "inline-flex size-8 items-center justify-center rounded-md text-info transition hover:bg-info/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info/60 cursor-pointer"
+  const baseClassName = "inline-flex size-8 items-center justify-center rounded-md transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info/60"
+  const enabledClassName = `${baseClassName} text-info hover:bg-info/10 cursor-pointer`
+  const disabledClassName = `${baseClassName} text-neutral-400 cursor-not-allowed`
+  const className = disabled ? disabledClassName : enabledClassName
 
-  if (toolId && externalUrl) {
+  if (toolId && externalUrl && !disabled) {
     return (
       <ExternalLinkButton
         toolId={toolId}
@@ -133,7 +139,8 @@ function ActionIconButton({
       type="button"
       className={className}
       aria-label={label}
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
     >
       <span className="size-4 [&>svg]:size-full">
         {icon}
@@ -356,6 +363,7 @@ export default function ExperimentsTable() {
                     <div className="flex justify-end gap-1.5">
                       {ACTION_ICONS.map((icon) => {
                         const linkInfo = getExternalLinkInfo(icon.action, experiment)
+                        const disabled = isActionDisabled(icon.action, experiment)
                         return (
                           <ActionIconButton
                             key={icon.label}
@@ -364,6 +372,7 @@ export default function ExperimentsTable() {
                             toolId={linkInfo?.toolId}
                             params={linkInfo?.params}
                             externalUrl={linkInfo?.externalUrl}
+                            disabled={disabled}
                             onClick={() => handleAction(icon.action, experiment)}
                           />
                         )

--- a/web-app/src/components/experimentActions.ts
+++ b/web-app/src/components/experimentActions.ts
@@ -1,0 +1,79 @@
+import type { ExperimentRead } from "../client/types.gen"
+
+// ============================================================================
+// ACTION AVAILABILITY LOGIC
+// ============================================================================
+// These functions determine when action buttons should be disabled.
+// Edit these functions to change the business logic for action availability.
+// ============================================================================
+
+/**
+ * Checks if an experiment has any defined steps.
+ *
+ * Steps represent the code-based workflow definition. When steps are present,
+ * the experiment was defined programmatically (via code editor).
+ */
+export function hasSteps(experiment: ExperimentRead): boolean {
+  return Array.isArray(experiment.steps) && experiment.steps.length > 0
+}
+
+/**
+ * Checks if an experiment has a non-empty graphical model.
+ *
+ * A graphical model is considered "non-empty" if it has at least one node.
+ * Edges alone are not sufficient since they require nodes to connect.
+ */
+export function hasGraphicalModel(experiment: ExperimentRead): boolean {
+  const model = experiment.graphical_model
+  if (!model || typeof model !== "object") return false
+  const nodes = (model as { nodes?: unknown[] }).nodes
+  return Array.isArray(nodes) && nodes.length > 0
+}
+
+/**
+ * Determines if the "Run/Schedule" action should be disabled.
+ *
+ * RULE: An experiment can only be run if it has some definition.
+ * Either steps (code-based) OR a graphical model must be present.
+ *
+ * @returns true if the action should be DISABLED
+ */
+export function isScheduleDisabled(experiment: ExperimentRead): boolean {
+  // Disable if the experiment has neither steps nor a graphical model
+  return !hasSteps(experiment) && !hasGraphicalModel(experiment)
+}
+
+/**
+ * Determines if the "Graphical Editor" action should be disabled.
+ *
+ * RULE: If an experiment has steps defined (code-based definition),
+ * opening the graphical editor would cause confusion or data loss.
+ * Users should use the code editor instead.
+ *
+ * @returns true if the action should be DISABLED
+ */
+export function isGraphicalEditorDisabled(experiment: ExperimentRead): boolean {
+  // Disable if steps are present (experiment is code-defined)
+  return hasSteps(experiment)
+}
+
+/**
+ * Returns whether a specific action should be disabled for an experiment.
+ *
+ * Add new action disable rules here as the project evolves.
+ *
+ * @param action - The action identifier (e.g., "schedule", "graphical_editor")
+ * @param experiment - The experiment to check
+ * @returns true if the action should be DISABLED, false otherwise
+ */
+export function isActionDisabled(action: string, experiment: ExperimentRead): boolean {
+  switch (action) {
+    case "schedule":
+      return isScheduleDisabled(experiment)
+    case "graphical_editor":
+      return isGraphicalEditorDisabled(experiment)
+    default:
+      // All other actions are always enabled
+      return false
+  }
+}


### PR DESCRIPTION
Implement logic to determine when action buttons should be disabled based on the presence of defined steps or a graphical model in experiments. This change enhances user experience by preventing invalid actions.